### PR TITLE
Add long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def main():
         author_email='contact@neptune.ai',
         url="https://github.com/neptune-ai/neptune-contrib",
         long_description=readme,
+        long_description_content_type="text/markdown",
         license='MIT License',
         install_requires=base_libs,
         extras_require=extras,


### PR DESCRIPTION
This PR adds `long_description_content_type` to  `setup.py` so the project description on PyPI is rendered properly.

The current project description looks like:

<img width="1126" alt="Screen Shot 2020-05-11 at 21 07 10" src="https://user-images.githubusercontent.com/17039389/81560040-92dfb500-93cb-11ea-9bde-ebe9148529dd.png">

https://pypi.org/project/neptune-contrib/0.20.0/